### PR TITLE
MSVC now is happy.

### DIFF
--- a/src/losslessops.cpp
+++ b/src/losslessops.cpp
@@ -87,13 +87,13 @@ static int64_t sqrt(int64_t n)
 
 saferet backend::pow(int64_t n, int64_t m)
 {
-	if (n < 0 and m % scale != 0) return make_badarg(m);
-	else if (n == 0 and m <= 0) return make_badarg(m);
-	else if (n == scale or m == 0) return clamp(scale);
+	if (n < 0 && m % scale != 0) return make_badarg(m);
+	else if (n == 0 && m <= 0) return make_badarg(m);
+	else if (n == scale || m == 0) return clamp(scale);
 	else if (m == scale) return clamp(n);
 	else if (m < 0) {
 		const saferet result = pow(n, -m);
-		if (result.flow == overflow or result.flow == underflow)
+		if (result.flow == overflow || result.flow == underflow)
 			return clamp(0);
 		else if (result.flow == badarg) return result;
 		

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -104,7 +104,7 @@ num& num::operator+=(num rhs)
 {
 	// If the sign of lhs and rhs aren't the same, we can always add.
 	// Same if either args are 0.
-	if (bi < 0 != rhs.bi < 0 || bi == 0 || rhs.bi == 0)
+	if ((bi < 0) != (rhs.bi < 0) || bi == 0 || rhs.bi == 0)
 		bi += rhs.bi;
 	else if (bi < 0) {
 		if (num_min - bi > rhs.bi)
@@ -123,7 +123,7 @@ num& num::operator-=(num rhs)
 {
 	// If sgn(lhs) == sgn(rhs) or rhs or lhs == 0, we can subtract.
 	// EXCEPT if rhs == num_min, as that would allow 0-(-2^63)=2^63.
-	if ((bi < 0 == rhs.bi < 0) ||
+	if (((bi < 0) == (rhs.bi < 0)) ||
 		((rhs.bi == 0 || bi == 0) && rhs.bi != num_min))
 		bi -= rhs.bi;
 	else if (rhs.bi == num_min) *this += num::max;

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -104,9 +104,9 @@ num& num::operator+=(num rhs)
 {
 	// If the sign of lhs and rhs aren't the same, we can always add.
 	// Same if either args are 0.
-	if (std::signbit(bi) != std::signbit(rhs.bi) or bi == 0 or rhs.bi == 0)
+	if (bi < 0 != rhs.bi < 0 || bi == 0 || rhs.bi == 0)
 		bi += rhs.bi;
-	else if (std::signbit(bi)) {
+	else if (bi < 0) {
 		if (num_min - bi > rhs.bi)
 			bi = num_min;
 		else bi += rhs.bi;
@@ -123,8 +123,8 @@ num& num::operator-=(num rhs)
 {
 	// If sgn(lhs) == sgn(rhs) or rhs or lhs == 0, we can subtract.
 	// EXCEPT if rhs == num_min, as that would allow 0-(-2^63)=2^63.
-	if ((std::signbit(bi) == std::signbit(rhs.bi)) or
-		((rhs.bi == 0 or bi == 0) and rhs.bi != num_min))
+	if ((bi < 0 == rhs.bi < 0) ||
+		((rhs.bi == 0 || bi == 0) && rhs.bi != num_min))
 		bi -= rhs.bi;
 	else if (rhs.bi == num_min) *this += num::max;
 	else *this += -rhs.bi;
@@ -158,7 +158,7 @@ num& num::operator/=(num rhs)
 
 num& num::operator%=(num rhs)
 {
-	const bool sign = std::signbit(rhs.bi);
+	const bool sign = rhs.bi < 0;
 	
 	bi = abs(*this).bi % abs(rhs).bi;
 	
@@ -242,12 +242,12 @@ num operator<=(num lhs, num rhs)
 
 num operator&&(num lhs, num rhs)
 {
-	return lhs.getraw() and rhs.getraw();
+	return lhs.getraw() && rhs.getraw();
 }
 
 num operator||(num lhs, num rhs)
 {
-	return lhs.getraw() or rhs.getraw();
+	return lhs.getraw() || rhs.getraw();
 }
 
 num operator-(num n)

--- a/tests/basic_arith.cpp
+++ b/tests/basic_arith.cpp
@@ -82,7 +82,7 @@ bool add_test()
 		const crolol::num ans = arg_and_ans.second;
 		const crolol::num result = lhs + rhs;
 		
-		if (not crolol::equals(ans, result)) {
+		if (!crolol::equals(ans, result)) {
 			success = false;
 			
 			std::cout << static_cast<std::string>(lhs) << " + "
@@ -127,7 +127,7 @@ bool sub_test()
 		const crolol::num ans = arg_and_ans.second;
 		const crolol::num result = lhs - rhs;
 		
-		if (not crolol::equals(ans, result)) {
+		if (!crolol::equals(ans, result)) {
 			success = false;
 			
 			std::cout << static_cast<std::string>(lhs) << " - "
@@ -174,7 +174,7 @@ bool mul_test()
 		const crolol::num ans = arg_and_ans.second;
 		const crolol::num result = lhs * rhs;
 		
-		if (not crolol::equals(ans, result)) {
+		if (!crolol::equals(ans, result)) {
 			success = false;
 			
 			std::cout << static_cast<std::string>(lhs) << " * "
@@ -220,7 +220,7 @@ bool div_test()
 		const crolol::num ans = arg_and_ans.second;
 		const crolol::num result = lhs / rhs;
 		
-		if (not crolol::equals(ans, result)) {
+		if (!crolol::equals(ans, result)) {
 			success = false;
 			
 			std::cout << static_cast<std::string>(lhs) << " / "
@@ -265,7 +265,7 @@ bool pow_test()
 		const crolol::num ans = arg_and_ans.second;
 		const crolol::num result = lhs ^ rhs;
 		
-		if (not crolol::equals(ans, result)) {
+		if (!crolol::equals(ans, result)) {
 			success = false;
 			
 			std::cout << static_cast<std::string>(lhs) << " ^ "

--- a/tests/lcg.cpp
+++ b/tests/lcg.cpp
@@ -24,7 +24,7 @@ int main()
 	for (const crolol::num& should_be: should_bes) {
 		const crolol::num ans = prng();
 		
-		if (not crolol::equals(should_be, ans)) {
+		if (!crolol::equals(should_be, ans)) {
 			std::cout << static_cast<std::string>(ans)
 				<< " should have been "
 				<< static_cast<std::string>(should_be)


### PR DESCRIPTION
Replace all `and` `not` `or` keywords with there logical counter-part.
Changed all `std::signbit(X)` to `X < 0` as all `X`'s are int's and MSVC was not happy with that.

`rad dude broham Today at 4:00 AM
but if they cause issues we can nuke 'em`
so i did.